### PR TITLE
Add CUDA 12 support and Colab build notebook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ add_executable(gflip3d ${GDEL3D_SOURCES})
 
 target_include_directories(gflip3d PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/GDelFlipping/src
-  ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
 )
 
 # Compiler avec NVCC et lier le runtime CUDA

--- a/GDelFlipping/src/gDel3D/GPU/KerPredicates.cu
+++ b/GDelFlipping/src/gDel3D/GPU/KerPredicates.cu
@@ -144,7 +144,7 @@ __forceinline__ __device__ float hash( int k )
     k ^= k >> 31;
     k ^= k << 31;
 
-    return int_as_float( k ); 
+    return __int_as_float( k );
 }
 
 __global__ void

--- a/GDelFlipping/src/gDel3D/GPU/ThrustWrapper.cu
+++ b/GDelFlipping/src/gDel3D/GPU/ThrustWrapper.cu
@@ -42,6 +42,7 @@ DAMAGE.
 #include "ThrustWrapper.h"
 
 #include <map>
+#include <cuda_runtime.h>
 
 #include <thrust/system/cuda/execution_policy.h>
 
@@ -113,17 +114,10 @@ public:
             // no allocation of the right size exists
             // create a new one with cuda::malloc
             // throw if cuda::malloc can't satisfy the request
-            try
+            cudaError_t err = cudaMalloc( reinterpret_cast<void**>(&result), numBytes );
+            if ( err != cudaSuccess )
             {
-                //std::cout << "CachedAllocator: no free block found; calling cudaMalloc " << numBytes << std::endl;
-
-                // allocate memory and convert cuda::pointer to raw pointer
-                result = thrust::device_malloc<char>( numBytes ).get();
-            }
-            catch( std::runtime_error &e )
-            {
-                // output an error message and exit
-                std::cerr << "thrust::device_malloc failed to allocate " << numBytes << " bytes!" << std::endl;
+                std::cerr << "cudaMalloc failed to allocate " << numBytes << " bytes!" << std::endl;
                 exit( -1 );
             }
         }

--- a/gdel3d_colab.ipynb
+++ b/gdel3d_colab.ipynb
@@ -1,0 +1,65 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# gDel3D on Google Colab\n",
+    "Install and build gDel3D with CUDA 12 on Ubuntu 22.04."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!nvidia-smi\n",
+    "!nvcc --version"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!apt-get update\n",
+    "!apt-get install -y build-essential git cmake nvidia-cuda-toolkit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!git clone https://github.com/Ludwig-H/gDel3D.git\n",
+    "%cd gDel3D\n",
+    "!cmake -S . -B build\n",
+    "!cmake --build build -j8"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the executable with your dataset, par exemple:\n",
+    "`!./build/gflip3d`"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- replace deprecated `thrust::device_malloc` with `cudaMalloc` in custom GPU containers and allocator
- adjust predicates hash to use `__int_as_float` for modern CUDA
- simplify CMake include paths and provide a Colab notebook for building on Ubuntu 22 / CUDA 12

## Testing
- `cmake .. && make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_b_68a4a99ae85c8326b5be9e9dc060c83e