### PR TITLE
Add EdgesDelaunay3D executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,39 +15,54 @@ set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 # Toolkit officiel (headers Thrust inclus)
 find_package(CUDAToolkit REQUIRED)
 
-# Inclure les sources .cpp/.cu du dossier src
-file(GLOB_RECURSE GDEL3D_SOURCES
+# Sources principales de la bibliothèque gDel3D
+file(GLOB_RECURSE GDEL3D_CORE
   CONFIGURE_DEPENDS
-  GDelFlipping/src/*.cpp
-  GDelFlipping/src/*.cu
+  GDelFlipping/src/gDel3D/*.cpp
+  GDelFlipping/src/gDel3D/*.cu
 )
 
 # Exclure fichiers Visual Studio
-list(FILTER GDEL3D_SOURCES EXCLUDE REGEX ".*\\.(vcxproj|sln)(\\.filters)?$")
+list(FILTER GDEL3D_CORE EXCLUDE REGEX ".*\\.(vcxproj|sln)(\\.filters)?$")
 
-add_executable(gflip3d ${GDEL3D_SOURCES})
-
-target_include_directories(gflip3d PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}/GDelFlipping/src
+# Executable de démonstration original
+add_executable(gflip3d
+  ${GDEL3D_CORE}
+  GDelFlipping/src/Demo.cpp
+  GDelFlipping/src/DelaunayChecker.cpp
+  GDelFlipping/src/InputCreator.cpp
+  GDelFlipping/src/RandGen.cpp
 )
 
-# Compiler avec NVCC et lier le runtime CUDA
-target_link_libraries(gflip3d PRIVATE CUDA::cudart)
-
-# Détecter et cibler automatiquement l'arch du GPU
-set_target_properties(gflip3d PROPERTIES
-  CUDA_ARCHITECTURES native
-  CUDA_SEPARABLE_COMPILATION ON
-  POSITION_INDEPENDENT_CODE ON
+# Nouveau programme pour extraire les arêtes du triangulation
+add_executable(EdgesDelaunay3D
+  ${GDEL3D_CORE}
+  GDelFlipping/src/EdgesDelaunay3D.cpp
 )
 
-# Option utile si Thrust/CUB se plaint de versions
-target_compile_definitions(gflip3d PRIVATE THRUST_IGNORE_CUB_VERSION_CHECK=1)
+foreach(target IN ITEMS gflip3d EdgesDelaunay3D)
+  target_include_directories(${target} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/GDelFlipping/src
+  )
 
-# Eviter que CMake impose -Werror=deprecated-declarations via toolchains exotiques
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  target_compile_options(gflip3d PRIVATE -Wno-deprecated-declarations)
-endif()
-if (CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
-  target_compile_options(gflip3d PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-fPIC>)
-endif()
+  # Compiler avec NVCC et lier le runtime CUDA
+  target_link_libraries(${target} PRIVATE CUDA::cudart)
+
+  # Détecter et cibler automatiquement l'arch du GPU
+  set_target_properties(${target} PROPERTIES
+    CUDA_ARCHITECTURES native
+    CUDA_SEPARABLE_COMPILATION ON
+    POSITION_INDEPENDENT_CODE ON
+  )
+
+  # Option utile si Thrust/CUB se plaint de versions
+  target_compile_definitions(${target} PRIVATE THRUST_IGNORE_CUB_VERSION_CHECK=1)
+
+  # Eviter que CMake impose -Werror=deprecated-declarations via toolchains exotiques
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(${target} PRIVATE -Wno-deprecated-declarations)
+  endif()
+  if (CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
+    target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-fPIC>)
+  endif()
+endforeach()

--- a/GDelFlipping/src/EdgesDelaunay3D.cpp
+++ b/GDelFlipping/src/EdgesDelaunay3D.cpp
@@ -1,0 +1,74 @@
+#include <fstream>
+#include <iostream>
+#include <set>
+#include <utility>
+
+#include "gDel3D/GpuDelaunay.h"
+
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        std::cerr << "Usage: " << argv[0] << " input.xyz output.txt\n";
+        return 1;
+    }
+    const char *inFile = argv[1];
+    const char *outFile = argv[2];
+
+    std::ifstream in(inFile);
+    if (!in) {
+        std::cerr << "Failed to open input file\n";
+        return 1;
+    }
+
+    Point3HVec points;
+    double x, y, z;
+    while (in >> x >> y >> z) {
+        Point3 p;
+        p._p[0] = x;
+        p._p[1] = y;
+        p._p[2] = z;
+        points.push_back(p);
+    }
+    in.close();
+
+    if (points.empty()) {
+        std::cerr << "No points loaded from input file\n";
+        return 1;
+    }
+
+    GDelOutput output;
+    GpuDel triangulator;
+    triangulator.compute(points, &output);
+
+    const int infIdx = static_cast<int>(points.size());
+    std::set<std::pair<int, int>> edges;
+
+    for (const Tet &t : output.tetVec) {
+        int v[4] = {t._v[0], t._v[1], t._v[2], t._v[3]};
+        for (int i = 0; i < 4; ++i) {
+            for (int j = i + 1; j < 4; ++j) {
+                int a = v[i];
+                int b = v[j];
+                if (a == infIdx || b == infIdx) {
+                    continue;
+                }
+                if (a > b) {
+                    std::swap(a, b);
+                }
+                edges.emplace(a, b);
+            }
+        }
+    }
+
+    std::ofstream out(outFile);
+    if (!out) {
+        std::cerr << "Failed to open output file\n";
+        return 1;
+    }
+    for (const auto &e : edges) {
+        out << e.first << " " << e.second << '\n';
+    }
+    out.close();
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add EdgesDelaunay3D program to output edges of 3D Delaunay triangulation
- refactor CMake to build both gflip3d and EdgesDelaunay3D executables

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_b_68a4d05ae6c083268a3980a5054f6b94