### PR TITLE
Support Colab default GPU environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.18)
 
 # Evite l'ancien module FindCUDA (supprimé) si un CMake trop récent est utilisé
 if(POLICY CMP0146)
@@ -49,14 +49,37 @@ foreach(target IN ITEMS gflip3d EdgesDelaunay3D)
   target_link_libraries(${target} PRIVATE CUDA::cudart)
 
   # Détecter et cibler automatiquement l'arch du GPU
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+    set(CUDA_ARCH native)
+  else()
+    execute_process(
+      COMMAND nvidia-smi --query-gpu=compute_cap --format=csv,noheader
+      OUTPUT_VARIABLE GPU_CAP
+      RESULT_VARIABLE GPU_CAP_RESULT
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(GPU_CAP_RESULT EQUAL 0 AND GPU_CAP)
+      string(REPLACE "." "" CUDA_ARCH ${GPU_CAP})
+    else()
+      # Valeur par défaut raisonnable (GPU Turing)
+      set(CUDA_ARCH 75)
+    endif()
+  endif()
+
   set_target_properties(${target} PROPERTIES
-    CUDA_ARCHITECTURES native
+    CUDA_ARCHITECTURES ${CUDA_ARCH}
     CUDA_SEPARABLE_COMPILATION ON
     POSITION_INDEPENDENT_CODE ON
   )
 
-  # Option utile si Thrust/CUB se plaint de versions
-  target_compile_definitions(${target} PRIVATE THRUST_IGNORE_CUB_VERSION_CHECK=1)
+  # Option utile si Thrust/CUB se plaint de versions et forcer le backend C++
+  # pour les fichiers compilés avec le compilateur hôte afin d'éviter
+  # l'inclusion de CUB qui provoque des erreurs lorsqu'il n'est pas
+  # compilé par NVCC.
+  target_compile_definitions(${target} PRIVATE
+    THRUST_IGNORE_CUB_VERSION_CHECK=1
+    $<$<COMPILE_LANGUAGE:CXX>:THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CPP>
+  )
 
   # Eviter que CMake impose -Werror=deprecated-declarations via toolchains exotiques
   if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/gdel3d_colab.ipynb
+++ b/gdel3d_colab.ipynb
@@ -24,8 +24,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!apt-get update\n",
-    "!apt-get install -y build-essential git cmake nvidia-cuda-toolkit"
+    "# La plupart des dépendances sont déjà présentes sur Colab.\n",
+    "# Si nécessaire, décommentez la ligne suivante pour les installer :\n",
+    "# !apt-get install -y build-essential git cmake nvidia-cuda-toolkit"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Allow building with the default Google Colab GPU stack by reducing the CMake requirement and detecting the GPU architecture when "native" isn't supported.
- Simplify the Colab notebook by removing mandatory package updates and making installation optional.
- Fix host compilation errors by forcing Thrust to use its C++ backend when building non-CUDA sources.

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_b_68a4dc456f048326880111a4cb4682e8