### PR TITLE
Fix linking and clamp CUDA arch for old toolkits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,26 +32,37 @@ target_include_directories(gdel3d_core PUBLIC
 )
 target_link_libraries(gdel3d_core PUBLIC CUDA::cudart)
 
-# Détecter et cibler automatiquement l'arch du GPU
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
-  set(CUDA_ARCH native)
+# Détection et ciblage automatique de l'architecture GPU avec limitation
+execute_process(
+  COMMAND nvidia-smi --query-gpu=compute_cap --format=csv,noheader
+  OUTPUT_VARIABLE GPU_CAP
+  RESULT_VARIABLE GPU_CAP_RESULT
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(GPU_CAP_RESULT EQUAL 0 AND GPU_CAP)
+  string(REPLACE "." "" CUDA_ARCH ${GPU_CAP})
 else()
-  execute_process(
-    COMMAND nvidia-smi --query-gpu=compute_cap --format=csv,noheader
-    OUTPUT_VARIABLE GPU_CAP
-    RESULT_VARIABLE GPU_CAP_RESULT
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-  if(GPU_CAP_RESULT EQUAL 0 AND GPU_CAP)
-    string(REPLACE "." "" CUDA_ARCH ${GPU_CAP})
-  else()
-    # Valeur par défaut raisonnable (GPU Turing)
-    set(CUDA_ARCH 75)
-  endif()
+  # Valeur par défaut raisonnable (GPU Turing)
+  set(CUDA_ARCH 75)
 endif()
 
+# nvcc des toolkits anciens n'acceptent pas les architectures les plus récentes.
+# On limite donc l'architecture à la plus élevée prise en charge par le toolkit
+# et on fournit un PTX de secours pour permettre la recompilation JIT.
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.8)
+  set(CUDA_MAX_ARCH 86)
+elseif(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.0)
+  set(CUDA_MAX_ARCH 89)
+else()
+  set(CUDA_MAX_ARCH 90)
+endif()
+if(CUDA_ARCH GREATER CUDA_MAX_ARCH)
+  set(CUDA_ARCH ${CUDA_MAX_ARCH})
+endif()
+set(CUDA_ARCH "${CUDA_ARCH}-real;${CUDA_ARCH}-virtual")
+
 set_target_properties(gdel3d_core PROPERTIES
-  CUDA_ARCHITECTURES ${CUDA_ARCH}
+  CUDA_ARCHITECTURES "${CUDA_ARCH}"
   CUDA_SEPARABLE_COMPILATION ON
   POSITION_INDEPENDENT_CODE ON
 )
@@ -81,20 +92,20 @@ add_executable(gflip3d
   GDelFlipping/src/RandGen.cpp
 )
 
+##
 # Les objets de gdel3d_core ont des dépendances circulaires (ex. GpuDelaunay.cu
 # appelle des fonctions de Splaying.cpp). Le linker omet sinon certains objets
 # de la bibliothèque statique, provoquant des "undefined reference" sur Colab.
-# On utilise la génératrice "LINK_LIBRARY" pour entourer automatiquement la
-# bibliothèque avec les options `--whole-archive`/`--no-whole-archive` de façon
-# portable afin que tous les symboles soient conservés.
-target_link_libraries(gflip3d PRIVATE
-  $<LINK_LIBRARY:WHOLE_ARCHIVE,gdel3d_core>
-)
+# Pour forcer l'inclusion de **tous** les objets, on lie la bibliothèque en
+# mode `--whole-archive` via l'expression génératrice LINK_LIBRARY.
+# Cette expression n'accepte pas de variable intermédiaire, mais pour éviter la
+# duplication on crée tout de même une variable contenant l'expression entière.
+set(GDEL3D_CORE_FULL $<LINK_LIBRARY:WHOLE_ARCHIVE,gdel3d_core>)
+
+target_link_libraries(gflip3d PRIVATE ${GDEL3D_CORE_FULL})
 
 # Nouveau programme pour extraire les arêtes de la triangulation
 add_executable(EdgesDelaunay3D
   GDelFlipping/src/EdgesDelaunay3D.cpp
 )
-target_link_libraries(EdgesDelaunay3D PRIVATE
-  $<LINK_LIBRARY:WHOLE_ARCHIVE,gdel3d_core>
-)
+target_link_libraries(EdgesDelaunay3D PRIVATE ${GDEL3D_CORE_FULL})


### PR DESCRIPTION
## Summary
- ensure executables link against full gdel3d_core using LINK_LIBRARY whole-archive expression
- detect GPU compute capability and cap to the maximum architecture supported by the installed CUDA toolkit, emitting PTX for forward compatibility

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_b_68a5609a5f008326934d64967ad5b166