### PR TITLE
Add PTX fallback to support older GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,10 +59,17 @@ endif()
 if(CUDA_ARCH GREATER CUDA_MAX_ARCH)
   set(CUDA_ARCH ${CUDA_MAX_ARCH})
 endif()
-set(CUDA_ARCH "${CUDA_ARCH}-real;${CUDA_ARCH}-virtual")
+
+# Assemblage de la liste finale des architectures.
+# On fournit toujours un PTX de secours en compute 52 pour
+# éviter l'erreur "invalid device function" sur les GPU plus anciens
+# que celui utilisé lors de la compilation. Le driver pourra
+# recompiler dynamiquement ce PTX pour les architectures >= 5.2.
+set(CUDA_ARCH_NATIVE "${CUDA_ARCH}-real;${CUDA_ARCH}-virtual")
+set(CUDA_ARCHITECTURES "52-virtual;${CUDA_ARCH_NATIVE}")
 
 set_target_properties(gdel3d_core PROPERTIES
-  CUDA_ARCHITECTURES "${CUDA_ARCH}"
+  CUDA_ARCHITECTURES "${CUDA_ARCHITECTURES}"
   CUDA_SEPARABLE_COMPILATION ON
   POSITION_INDEPENDENT_CODE ON
 )

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ cmake --build build
 ./build/EdgesDelaunay3D  # optional edge extractor
 ```
 
+The build system automatically detects your GPU and also embeds a
+PTX fallback for compute capability 5.2. This allows the binaries to run
+on older devices and avoids runtime errors such as
+`cudaErrorInvalidDeviceFunction`.
+
 Tested on Ubuntu 22.04 with CUDA 12.5. A Visual Studio 2012 project is provided for Windows users.
 
 ## Notes


### PR DESCRIPTION
## Summary
- Always embed a compute 5.2 PTX fallback so binaries run on older GPUs
- Document GPU detection and PTX fallback to avoid `cudaErrorInvalidDeviceFunction`

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_b_68a56c2723b88326bfa53e14a58cafbf