### PR TITLE
Include CUDA headers for consistent Thrust symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ list(FILTER GDEL3D_CORE EXCLUDE REGEX ".*\\.(vcxproj|sln)(\\.filters)?$")
 add_library(gdel3d_core ${GDEL3D_CORE})
 target_include_directories(gdel3d_core PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/GDelFlipping/src
+  ${CUDAToolkit_INCLUDE_DIRS}
 )
 target_link_libraries(gdel3d_core PUBLIC CUDA::cudart)
 


### PR DESCRIPTION
## Summary
- ensure gdel3d_core uses CUDA toolkit includes so host compilation picks the same Thrust headers as device code

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_b_68a58163f7788326b90d21653ecea174