### PR TITLE
Fix CUDA device linking for executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,10 @@ add_executable(gflip3d
   $<TARGET_OBJECTS:gdel3d_core>
 )
 target_link_libraries(gflip3d PRIVATE gdel3d_core CUDA::cudart)
+set_target_properties(gflip3d PROPERTIES
+  LINKER_LANGUAGE CUDA
+  CUDA_SEPARABLE_COMPILATION ON
+)
 
 # Nouveau programme pour extraire les arêtes de la triangulation
 add_executable(EdgesDelaunay3D
@@ -121,3 +125,7 @@ add_executable(EdgesDelaunay3D
   $<TARGET_OBJECTS:gdel3d_core>
 )
 target_link_libraries(EdgesDelaunay3D PRIVATE gdel3d_core CUDA::cudart)
+set_target_properties(EdgesDelaunay3D PROPERTIES
+  LINKER_LANGUAGE CUDA
+  CUDA_SEPARABLE_COMPILATION ON
+)


### PR DESCRIPTION
## Summary
- enable CUDA device linking for `gflip3d` and `EdgesDelaunay3D`

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*
- `apt-get install -y nvidia-cuda-toolkit` *(fails: needs 2368 MB of archives)*

------
https://chatgpt.com/codex/tasks/task_b_68a59b2cf2dc8326991adaed2d941fd2