### PR TITLE
Add runtime CUDA device capability check

### DIFF
--- a/GDelFlipping/src/Demo.cpp
+++ b/GDelFlipping/src/Demo.cpp
@@ -42,6 +42,7 @@ DAMAGE.
 #include <iomanip>
 
 #include "gDel3D/GpuDelaunay.h"
+#include "gDel3D/GPU/CudaWrapper.h"
 
 #include "DelaunayChecker.h"
 #include "InputCreator.h"
@@ -58,7 +59,8 @@ GDelOutput   output;
 void summarize( int pointNum, const GDelOutput& output );
 
 int main( int argc, const char* argv[] )
-{  
+{
+    ensureCudaDevice( deviceIdx );
     CudaSafeCall( cudaSetDevice( deviceIdx ) );
     CudaSafeCall( cudaDeviceReset() );
 

--- a/GDelFlipping/src/EdgesDelaunay3D.cpp
+++ b/GDelFlipping/src/EdgesDelaunay3D.cpp
@@ -4,6 +4,7 @@
 #include <utility>
 
 #include "gDel3D/GpuDelaunay.h"
+#include "gDel3D/GPU/CudaWrapper.h"
 
 int main(int argc, char **argv) {
     if (argc != 3) {
@@ -35,6 +36,7 @@ int main(int argc, char **argv) {
         return 1;
     }
 
+    ensureCudaDevice();
     GDelOutput output;
     GpuDel triangulator;
     triangulator.compute(points, &output);

--- a/GDelFlipping/src/gDel3D/GPU/CudaWrapper.h
+++ b/GDelFlipping/src/gDel3D/GPU/CudaWrapper.h
@@ -143,6 +143,26 @@ inline void cuPrintMemory( const char* inStr )
     return;
 }
 
+inline void ensureCudaDevice( int deviceIdx = 0 )
+{
+    int deviceCount = 0;
+    cudaError err = cudaGetDeviceCount( &deviceCount );
+    if ( err != cudaSuccess || deviceCount == 0 )
+    {
+        fprintf( stderr, "No CUDA-capable device detected\n" );
+        exit( -1 );
+    }
+
+    cudaDeviceProp prop;
+    CudaSafeCall( cudaGetDeviceProperties( &prop, deviceIdx ) );
+    int cc = prop.major * 10 + prop.minor;
+    if ( cc < 52 )
+    {
+        fprintf( stderr, "Compute capability %d.%d is lower than required 5.2\n", prop.major, prop.minor );
+        exit( -1 );
+    }
+}
+
 // Obtained from: C:\ProgramData\NVIDIA Corporation\GPU SDK\C\common\inc\cutil_inline_runtime.h
 // This function returns the best GPU (with maximum GFLOPS)
 inline int cutGetMaxGflopsDeviceId()


### PR DESCRIPTION
## Summary
- add `ensureCudaDevice` helper to validate GPU presence and compute capability
- call the check from demos to fail fast when CUDA hardware is missing or too old

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/gflip3d` *(fails: No CUDA-capable device detected)*

------
https://chatgpt.com/codex/tasks/task_b_68a5a183c9688326acee78c9d76526bb