### PR TITLE
Fix host-side swap in predicate wrapper

### DIFF
--- a/GDelFlipping/src/gDel3D/CPU/PredWrapper.cpp
+++ b/GDelFlipping/src/gDel3D/CPU/PredWrapper.cpp
@@ -40,6 +40,7 @@ DAMAGE.
 */
 
 #include "PredWrapper.h"
+#include <algorithm>
 
 void PredWrapper::init( const Point3HVec& pointVec, Point3 ptInfty )
 {
@@ -428,8 +429,8 @@ int             pi4
         {
             if ( idx[j] < idx[j - 1] )
             {
-                cuSwap( idx[j], idx[j - 1] );
-                cuSwap( ord[j], ord[j - 1] );   // Note order
+                std::swap( idx[j], idx[j - 1] );
+                std::swap( ord[j], ord[j - 1] );   // Note order
                 ++swapCount;
             }
         }


### PR DESCRIPTION
## Summary
- replace CUDA-only `cuSwap` calls with `std::swap` in CPU predicate wrapper
- include `<algorithm>` to provide `std::swap`

## Testing
- `cmake ..`
- `make gdel3d_core -j$(nproc)`
- `make -j$(nproc)` *(fails: fatal error: stdlib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68a5c0f64b28832688b1c726684a755d